### PR TITLE
Explicitly load ImageMagick in runtests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@ using Plots; gr()
 using VisualRegressionTests
 using Test, Pkg, Random
 
+using ImageMagick
+
 # workaround for GR warnings
 ENV["GKSwstype"] = "100"
 


### PR DESCRIPTION
My understanding of the problem of Travis with Linux is that system zlib is being loaded (and Ubuntu Xenial comes with zlib v1.2.8: https://packages.ubuntu.com/source/xenial/zlib), which is not compatible with libpng in ImageMagick.  To avoid issues, my solution is to explicitly load `ImageMagick.jl`, which makes sure that the right libraries are loaded, instead of picking up system libraries.

Unrelated, Travis doesn't run any test on macOS, so I'm not entirely sure what's the point of spawning those jobs.